### PR TITLE
fix: Prevent placing markers after a win

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,6 +35,20 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with unittest and calculate coverage
+      run: |
+        coverage run -m unittest discover -s tests -t .
+        coverage xml -o coverage.xml
+    - name: Display current directory and list files
+      run: |
+        pwd
+        ls -la
+    - name: Create Coverage Report
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: orgoro/coverage@v3.2
+      with:
+        coverageFile: coverage.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
 #    - name: Test with pytest
 #      run: |
 #        pytest

--- a/app.py
+++ b/app.py
@@ -35,10 +35,11 @@ def index():
 def play(cell):
     # breakpoint()
     global current_player
-    if board[cell] == ' ':
-        board[cell] = current_player
-        if not check_winner():
-            current_player = 'O' if current_player == 'X' else 'X'
+    if not check_winner():
+        if board[cell] == ' ':
+            board[cell] = current_player
+            if not check_winner():
+                current_player = 'O' if current_player == 'X' else 'X'
     return redirect(url_for('index'))
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
         'Flask==2.3.3',
     ],
     extras_require={
-        'dev': ['flake8'],
+        'dev': ['coverage','flake8'],
     },
     entry_points={
         'console_scripts': [

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,38 @@
+import unittest
+import app
+
+class TestApp(unittest.TestCase):
+    def setUp(self):
+        # .testing is a flag for Flask to know the app is in test mode
+        app.app.testing = True
+        self.client = app.app.test_client()
+        # Reset global board between tests, this is a requirement of how Flask works
+        app.board[:] = [" "] * 9
+        app.current_player = "X"
+
+    def test_home_route(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        # optional: check that the board was rendered
+        self.assertIn(b"Tic Tac Toe", response.data)
+        self.assertIn(b"Current Player: X", response.data)
+
+    def test_no_play_after_win(self):
+        self.client.get("/play/0")
+        self.client.get("/play/1")
+        self.client.get("/play/3")
+        self.client.get("/play/4")
+        response = self.client.get("/play/4")
+        self.assertEqual(302, response.status_code)
+        self.assertNotIn(b"Player X wins!", response.data)
+        response = self.client.get("/play/6", follow_redirects=True)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(['X', 'O', ' ',
+                          'X', 'O', ' ',
+                          'X', ' ', ' '], app.board)
+        # Game is won. Now test that another marker cant be placed.
+        self.assertIn(b"Player X wins!", response.data)
+        response = self.client.get("/play/7")
+        self.assertEqual(['X', 'O', ' ',
+                          'X', 'O', ' ',
+                          'X', ' ', ' '], app.board)


### PR DESCRIPTION
## Description
Game isn't ending after winning or losing. Players can still place markers.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Played the game a few rounds, won as X & Y and checked that no more markers could be placed until the Reset button is pressed.

## Checklist:
- [x] I have followed the coding style guidelines of this project
- [x] I have reviewed my own code
- [x] I have commented hard-to-understand areas of my code
- [x] I have added docstrings to all public functions/methods
- [x] I have used descriptive variable names to make my code easier to understand
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issue(s)
Fixes #4